### PR TITLE
Scale down pr environment

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -102,4 +102,5 @@ jobs:
           region: westeurope
           subscriptionId: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           template: ./deploy/main.bicep
+          parameters: isProduction=true
           failOnStdErr: false

--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -2,6 +2,7 @@ targetScope = 'subscription'
 
 param location string = 'westeurope'
 param imageTag string = 'latest'
+param isProduction bool = false
 
 var resourceGroupName = 'rg-xprtzbv-website'
 var containerAppIdentityName = 'id-xprtzbv-website'
@@ -24,6 +25,7 @@ module containerAppWebsite 'modules/container-app-website.bicep' = {
     containerAppUserAssignedIdentityResourceId: containerAppIdentity.id
     containerAppUserAssignedIdentityClientId: containerAppIdentity.properties.clientId
     imageTag: imageTag
+    isProduction: isProduction
   }
 }
 

--- a/deploy/modules/container-app-website.bicep
+++ b/deploy/modules/container-app-website.bicep
@@ -2,6 +2,7 @@ param location string
 param containerAppUserAssignedIdentityResourceId string
 param containerAppUserAssignedIdentityClientId string
 param imageTag string = 'latest'
+param isProduction bool
 
 var name = take('ctap-xprtzbv-website-${imageTag}', 32)
 
@@ -55,8 +56,8 @@ resource containerApp 'Microsoft.App/containerApps@2023-08-01-preview' = {
         }
       ]
       scale: {
-       minReplicas: 1
-       maxReplicas: 10
+       minReplicas: isProduction ? 1 : 0
+       maxReplicas: isProduction ? 10 : 1
       }
     }
   }

--- a/deploy/modules/container-app-website.bicep
+++ b/deploy/modules/container-app-website.bicep
@@ -57,7 +57,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-08-01-preview' = {
       ]
       scale: {
        minReplicas: isProduction ? 1 : 0
-       maxReplicas: isProduction ? 10 : 1
+       maxReplicas: 1
       }
     }
   }


### PR DESCRIPTION
This PR updates the deployment template to include a new parameter `isProduction` which allows scaling down the PR environment by setting `minReplicas` to 0 and `maxReplicas` to 1 when `isProduction` is false.